### PR TITLE
Remove indir

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -46,7 +46,7 @@ rule all:
     input:
         tandem_pas_TE = expand(os.path.join(config["outdir"],
                 str(config["atlas_version"]) + ".tandem_pas.terminal_exons.{strandedness}.bed"),
-                strandedness = ["unstranded","stranded"]),
+                strandedness = config["strandedness"]),
 
     
 rule create_log_dir:
@@ -72,10 +72,8 @@ rule select_tandem_pas:
     """
     input:
         created_dirs = os.path.join(logs,"created_dirs.tmp"),
-        BED_pas_atlas = os.path.join(config["indir"],
-                config['polyasites']),
-        GTF_annotation = os.path.join(config["indir"],
-                config['gtf']),
+        BED_pas_atlas = config['polyasites'],
+        GTF_annotation = config['gtf'],
         SCRIPT_ = os.path.join(
             config['scriptsdir'],
             "mz-select-pas-subset.pl")
@@ -178,8 +176,7 @@ rule filter_on_ambiguous_annotation:
     input:
         TSV_tandem_pas_terminal_exons = os.path.join(config["outdir"],
                 str(config["atlas_version"]) + ".tandem_pas.terminal_exons.tsv"),
-        GTF_annotation = os.path.join(config["indir"],
-                config['gtf']),
+        GTF_annotation = config['gtf'],
         SCRIPT_ = os.path.join(
             config["scriptsdir"],
             "mz-remove-overlapping-genes_{strandedness}.pl")

--- a/config.yaml
+++ b/config.yaml
@@ -10,9 +10,9 @@ logdir: logs
 scriptsdir: scripts
 
 # annotations (files to be placed into dir specified as indir)
-polyasites: annotations/atlas.clusters.2.0.GRCh38.96.bed.gz
-atlas_version: 2.0 #For naming output tandem PAS file
-gtf: annotations/gencode.v38.annotation.chr_removed.gtf.gz
+polyasites: # e.g. annotations/atlas.clusters.2.0.GRCh38.96.bed.gz
+atlas_version: # e.g. 2.0 #For naming output tandem PAS file
+gtf: # e.g. annotations/gencode.v38.annotation.chr_removed.gtf.gz
 
 # directory for results
 outdir: results
@@ -38,7 +38,7 @@ biotype_values:
   - protein_coding
 
 # number of nucleotides by which each terminal exon is extended at the 3' end
-three_prime_offset: 100
+three_prime_offset: 0
 
 # locusExtension: up/down extension of transcript locus to catch reads that start/end beyond transcript boundaries
 locus_extension: 100

--- a/config.yaml
+++ b/config.yaml
@@ -9,17 +9,17 @@ logdir: logs
 # directory that contains the scripts
 scriptsdir: scripts
 
-# directory for poly(A) sites and gtf
-indir: annotations
-
 # annotations (files to be placed into dir specified as indir)
-polyasites: #atlas.clusters.2.0.GRCh38.96.bed.gz
-atlas_version: #2.0 For naming output tandem PAS file
-gtf: #gencode.v38.gtf.gz
+polyasites: annotations/atlas.clusters.2.0.GRCh38.96.bed.gz
+atlas_version: 2.0 #For naming output tandem PAS file
+gtf: annotations/gencode.v38.annotation.chr_removed.gtf.gz
 
 # directory for results
 outdir: results
 
+# Caculate TPAS for stranded or unstranded data, or both?
+# specify as list of strings (e.g. ["unstranded", "stranded"])
+strandedness: ["stranded"]
 
 #-------------------------------------------------------------------------------
 # params for tandem pas creation
@@ -38,7 +38,7 @@ biotype_values:
   - protein_coding
 
 # number of nucleotides by which each terminal exon is extended at the 3' end
-three_prime_offset: 0
+three_prime_offset: 100
 
 # locusExtension: up/down extension of transcript locus to catch reads that start/end beyond transcript boundaries
 locus_extension: 100


### PR DESCRIPTION
- remove input dir, whole path to infiles have instead to be specified; This is more flexible when importing the workflow in other snakemake workflows as module or subworkflow. 

- read strandedness from config (as a list). Like this, not both, stranded and unstranded output files, have to be created in every run.